### PR TITLE
Convert Phoneme list in the README to a Markdown Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,49 +63,47 @@ isabella IH Z AA B EH L AA
 
 This is a complete list of phonemes you can use:
 
-```
-Phoneme  Example  Translation
--------  -------  -----------
-AA       odd      AA D
-AE       at       AE T
-AH       hut      HH AH T
-AO       ought    AO T
-AW       cow      K AW
-AY       hide     HH AY D
-B        be       B IY
-CH       cheese   CH IY Z
-D        dee      D IY
-DH       thee     DH IY
-EH       Ed       EH D
-ER       hurt     HH ER T
-EY       ate      EY T
-F        fee      F IY
-G        green    G R IY N
-HH       he       HH IY
-IH       it       IH T
-IY       eat      IY T
-JH       gee      JH IY
-K        key      K IY
-L        lee      L IY
-M        me       M IY
-N        knee     N IY
-NG       ping     P IH NG
-OW       oat      OW T
-OY       toy      T OY
-P        pee      P IY
-R        read     R IY D
-S        sea      S IY
-SH       she      SH IY
-T        tea      T IY
-TH       theta    TH EY T AH
-UH       hood     HH UH D
-UW       two      T UW
-V        vee      V IY
-W        we       W IY
-Y        yield    Y IY L D
-Z        zee      Z IY
-ZH       seizure  S IY ZH ER
-```
+| Phoneme | Example | Translation |
+| ------- | ------- | ----------- |
+| AA      | odd     | AA D        |
+| AE      | at      | AE T        |
+| AH      | hut     | HH AH T     |
+| AO      | ought   | AO T        |
+| AW      | cow     | K AW        |
+| AY      | hide    | HH AY D     |
+| B       | be      | B IY        |
+| CH      | cheese  | CH IY Z     |
+| D       | dee     | D IY        |
+| DH      | thee    | DH IY       |
+| EH      | Ed      | EH D        |
+| ER      | hurt    | HH ER T     |
+| EY      | ate     | EY T        |
+| F       | fee     | F IY        |
+| G       | green   | G R IY N    |
+| HH      | he      | HH IY       |
+| IH      | it      | IH T        |
+| IY      | eat     | IY T        |
+| JH      | gee     | JH IY       |
+| K       | key     | K IY        |
+| L       | lee     | L IY        |
+| M       | me      | M IY        |
+| N       | knee    | N IY        |
+| NG      | ping    | P IH NG     |
+| OW      | oat     | OW T        |
+| OY      | toy     | T OY        |
+| P       | pee     | P IY        |
+| R       | read    | R IY D      |
+| S       | sea     | S IY        |
+| SH      | she     | SH IY       |
+| T       | tea     | T IY        |
+| TH      | theta   | TH EY T AH  |
+| UH      | hood    | HH UH D     |
+| UW      | two     | T UW        |
+| V       | vee     | V IY        |
+| W       | we      | W IY        |
+| Y       | yield   | Y IY L D    |
+| Z       | zee     | Z IY        |
+| ZH      | seizure | S IY ZH ER  |
 
 All alternate pronunciations must be marked with paranthesized serial numbers starting from (2) for the second pronunciation. The marker (1) is omitted. For example:
 


### PR DESCRIPTION
For added readability, convert the Phoneme list from a code block to a Markdown Table.
### Before:

![screen shot 2015-04-22 at 11 32 07 am](https://cloud.githubusercontent.com/assets/447041/7278415/627b3d00-e8e3-11e4-830b-f28f583c25f6.png)
### After:

![screen shot 2015-04-22 at 11 34 40 am](https://cloud.githubusercontent.com/assets/447041/7278456/9aab8f18-e8e3-11e4-837d-05438b29932b.png)
